### PR TITLE
API improvements

### DIFF
--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -64,6 +64,11 @@ func (inv *Inventory) VNums() []ocfl.VNum {
 	return vnums
 }
 
+// Inventory digest from inventory read
+func (inv Inventory) Digest() string {
+	return inv.digest
+}
+
 // ContentPath returns the content path for the logical path present in the
 // state for version vnum. The content path is relative to the object's root
 // directory (i.e, as it appears in the inventory manifest). If vnum is empty,

--- a/ocflv1/object.go
+++ b/ocflv1/object.go
@@ -57,6 +57,11 @@ func GetObject(ctx context.Context, fsys ocfl.FS, root string) (*Object, error) 
 	return obj, nil
 }
 
+// Root returns the object's FS and root directory
+func (obj *Object) Root() (ocfl.FS, string) {
+	return obj.fsys, obj.rootDir
+}
+
 func (obj *Object) Info(ctx context.Context) (*ocfl.ObjInfo, error) {
 	if obj.info == nil {
 		var err error

--- a/ocflv1/object.go
+++ b/ocflv1/object.go
@@ -30,6 +30,10 @@ type Object struct {
 	rootDir string
 	// cache of object info
 	info *ocfl.ObjInfo
+	// cache of inventory
+	inv *Inventory
+	// cache of inventory sidecar
+	sidecarDigest string
 }
 
 // GetObject returns a new Object with loaded inventory.
@@ -57,28 +61,36 @@ func GetObject(ctx context.Context, fsys ocfl.FS, root string) (*Object, error) 
 	return obj, nil
 }
 
-// Root returns the object's FS and root directory
+// Root returns the object's FS and root directory. The root directory is a path
+// relative to the object's ocfl.FS.
 func (obj *Object) Root() (ocfl.FS, string) {
 	return obj.fsys, obj.rootDir
 }
 
+// Info returns a description of the object's top-level directory contents. The
+// value is cached: subsequent calls return the same value.
 func (obj *Object) Info(ctx context.Context) (*ocfl.ObjInfo, error) {
-	if obj.info == nil {
-		var err error
-		obj.info, err = ocfl.ReadObjInfo(ctx, obj.fsys, obj.rootDir)
-		if err != nil {
-			return nil, err
-		}
+	if obj.info != nil {
+		return obj.info, nil
 	}
-	return obj.info, nil
-}
-
-func (obj *Object) Inventory(ctx context.Context) (*Inventory, error) {
-	info, err := obj.Info(ctx)
+	inf, err := ocfl.ReadObjInfo(ctx, obj.fsys, obj.rootDir)
 	if err != nil {
 		return nil, err
 	}
-	if err := ctx.Err(); err != nil {
+	obj.info = inf
+	return obj.info, nil
+}
+
+// Inventory returns the root inventory for the object. The first time
+// Inventory() is called, the inventory is downloaded, validated, and returned.
+// An error is returned if the inventory cannot be read or it is invalid.  The
+// value is cached: subsequent calls return the same value.
+func (obj *Object) Inventory(ctx context.Context) (*Inventory, error) {
+	if obj.inv != nil {
+		return obj.inv, nil
+	}
+	info, err := obj.Info(ctx)
+	if err != nil {
 		return nil, err
 	}
 	name := path.Join(obj.rootDir, inventoryFile)
@@ -90,25 +102,37 @@ func (obj *Object) Inventory(ctx context.Context) (*Inventory, error) {
 	if err := results.Err(); err != nil {
 		return nil, fmt.Errorf("reading inventory: %w", err)
 	}
-	return inv, err
+	obj.inv = inv
+	return obj.inv, nil
 }
 
 // InventorySidecar returns the digest stored in the root inventory sidecar
-// file.
+// file.  The value is cached: subsequent calls return the same value.
 func (obj *Object) InventorySidecar(ctx context.Context) (string, error) {
+	if obj.sidecarDigest != "" {
+		return obj.sidecarDigest, nil
+	}
 	inf, err := obj.Info(ctx)
 	if err != nil {
 		return "", err
 	}
-	sidecar := path.Join(obj.rootDir, inventoryFile+"."+inf.Algorithm)
-	return readInventorySidecar(ctx, obj.fsys, sidecar)
+	sidecarFile := path.Join(obj.rootDir, inventoryFile+"."+inf.Algorithm)
+	sidecar, err := readInventorySidecar(ctx, obj.fsys, sidecarFile)
+	if err != nil {
+		return "", err
+	}
+	obj.sidecarDigest = sidecar
+	return obj.sidecarDigest, nil
 }
 
+// Validate validations the object using the given validation Options
 func (obj *Object) Validate(ctx context.Context, opts ...ValidationOption) *validation.Result {
 	_, r := ValidateObject(ctx, obj.fsys, obj.rootDir, opts...)
 	return r
 }
 
+// NewStage returns a Stage based on the specified version of the object. If ver
+// is the empty value, the head version is used.
 func (obj *Object) NewStage(ctx context.Context, ver ocfl.VNum, opts ...ocfl.StageOption) (*ocfl.Stage, error) {
 	inv, err := obj.Inventory(ctx)
 	if err != nil {

--- a/ocflv1/store.go
+++ b/ocflv1/store.go
@@ -165,8 +165,8 @@ func (s *Store) Spec() ocfl.Spec {
 
 // ScanObjects scans the storage root for objects, returning a map of path/ocfl
 // version pairs. No validation checks are performed.
-func (s *Store) ScanObjects(ctx context.Context, opts *ScanObjectsOpts) (map[string]ocfl.Spec, error) {
-	return ScanObjects(ctx, s.fsys, s.rootDir, opts)
+func (s *Store) ScanObjects(ctx context.Context, fn func(*Object) error, opts *ScanObjectsOpts) error {
+	return ScanObjects(ctx, s.fsys, s.rootDir, fn, opts)
 }
 
 // Validate performs complete validation on the store

--- a/ocflv1/store_validation.go
+++ b/ocflv1/store_validation.go
@@ -132,24 +132,15 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 	//E088: An OCFL Storage Root MUST NOT contain directories or
 	//sub-directories other than as a directory hierarchy used to store OCFL
 	//Objects or for storage root extensions.
-	scan, err := ScanObjects(ctx, fsys, root, &ScanObjectsOpts{
-		Strict: true,
-	})
-	if err != nil {
-		if errors.Is(err, ErrEmptyDirs) {
-			result.LogFatal(lgr, ec(err, codes.E073.Ref(ocflV)))
-		}
-		if errors.Is(err, ErrNonObject) {
-			result.LogFatal(lgr, ec(err, codes.E084.Ref(ocflV)))
-		}
-	}
-	for p, v := range scan {
+	scanFn := func(obj *Object) error {
+		p := obj.rootDir
+		v := obj.info.Declaration.Version
 		objLgr := lgr.WithName(p)
 		if ocflV.Cmp(v) < 0 {
 			result.LogFatal(objLgr, ErrObjectVersion)
 		}
 		if opts.SkipObjects {
-			continue
+			return nil
 		}
 		errMsg := "invalid object"
 		objPath := path.Join(root, p)
@@ -158,9 +149,8 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 			ValidationLogger(objLgr),
 			appendResult(result),
 		}
-		obj, _ := ValidateObject(ctx, fsys, objPath, objValidOpts...)
-		if err := result.Err(); err != nil {
-			continue
+		if err := obj.Validate(ctx, objValidOpts...).Err(); err != nil {
+			return nil // return nil to continue validating objects in the Scan
 		}
 		// FIXME: the object inventory is read twice, for Validation and then
 		// again here. The is a case where caching the inventory in the object
@@ -168,20 +158,30 @@ func ValidateStore(ctx context.Context, fsys ocfl.FS, root string, vops ...Valid
 		inv, err := obj.Inventory(ctx) // I just need the ID
 		if err != nil {
 			result.LogFatal(objLgr, fmt.Errorf("%s: %w", errMsg, err))
-			continue
+			return nil
 		}
 		if layoutFunc != nil {
 			p, err := layoutFunc(inv.ID)
 			if err != nil {
 				err := fmt.Errorf("object id '%s' is not compatible with the storage root layout: %w", inv.ID, err)
 				result.LogWarn(objLgr, err)
-				continue
+				return nil
 			}
 			if p != objPath {
 				err := fmt.Errorf("object path '%s' does not conform with storage root layout. expected '%s'", objPath, p)
 				result.LogWarn(objLgr, err)
-				continue
+				return nil
 			}
+		}
+		return nil
+	}
+
+	if err := ScanObjects(ctx, fsys, root, scanFn, &ScanObjectsOpts{Strict: true}); err != nil {
+		if errors.Is(err, ErrEmptyDirs) {
+			result.LogFatal(lgr, ec(err, codes.E073.Ref(ocflV)))
+		}
+		if errors.Is(err, ErrNonObject) {
+			result.LogFatal(lgr, ec(err, codes.E084.Ref(ocflV)))
 		}
 	}
 	return result


### PR DESCRIPTION
- `ocflv1.ScanObjects()` now takes a callback function, allowing access each `ocflv1.Object` in the storage root.
- `ocflv1.Object` caches values for `Inventory()` and `InventorySidecar()` to prevent repeat downloads.