### PR TITLE
Improvements to inventory construction and Commit() implementation

### DIFF
--- a/cmd/gocfl/cmd/commit.go
+++ b/cmd/gocfl/cmd/commit.go
@@ -127,9 +127,6 @@ func runCommit(ctx context.Context, conf *Config) {
 		ocflv1.WithUser(commitFlags.userName, commitFlags.userAddr),
 		ocflv1.WithLogger(log),
 	}
-	if commitFlags.dryRun {
-		commitOpts = append(commitOpts, ocflv1.WithNoWrite())
-	}
 	commitFn := func(w io.Writer) error {
 		return store.Commit(ctx, commitFlags.objectID, stage, commitOpts...)
 	}

--- a/cmd/gocfl/cmd/commit.go
+++ b/cmd/gocfl/cmd/commit.go
@@ -131,7 +131,6 @@ func runCommit(ctx context.Context, conf *Config) {
 		commitOpts = append(commitOpts, ocflv1.WithNoWrite())
 	}
 	commitFn := func(w io.Writer) error {
-		commitOpts = append(commitOpts, ocflv1.WithProgressWriter(w))
 		return store.Commit(ctx, commitFlags.objectID, stage, commitOpts...)
 	}
 	if err := commitUI.Start(commitFn); err != nil {

--- a/digest/errors.go
+++ b/digest/errors.go
@@ -24,7 +24,7 @@ type MapDigestConflictErr struct {
 }
 
 func (d *MapDigestConflictErr) Error() string {
-	return "digest conflict: " + string(d.Digest)
+	return fmt.Sprintf("digest conflict for: '%s'", d.Digest)
 }
 
 // MapPathConflictErr indicates a path appears more than once in the digest map.
@@ -35,7 +35,7 @@ type MapPathConflictErr struct {
 }
 
 func (p *MapPathConflictErr) Error() string {
-	return "path conflict: " + string(p.Path)
+	return fmt.Sprintf("path conflict for: '%s'", p.Path)
 }
 
 // MapPathInvalidErr indicates an invalid path in a Map.
@@ -44,5 +44,5 @@ type MapPathInvalidErr struct {
 }
 
 func (p *MapPathInvalidErr) Error() string {
-	return "invalid path: " + string(p.Path)
+	return fmt.Sprintf("invalid path: '%s'", p.Path)
 }

--- a/digest/errors.go
+++ b/digest/errors.go
@@ -1,6 +1,10 @@
 package digest
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 // DigestErr is returned when content's digest conflicts with an expected value
 type DigestErr struct {
@@ -46,3 +50,7 @@ type MapPathInvalidErr struct {
 func (p *MapPathInvalidErr) Error() string {
 	return fmt.Sprintf("invalid path: '%s'", p.Path)
 }
+
+// ErrMapMakerExists is returned when calling Add with a path and digest that
+// are already present in the MapMaker
+var ErrMapMakerExists = errors.New("path and digest exist")

--- a/digest/errors.go
+++ b/digest/errors.go
@@ -1,9 +1,8 @@
 package digest
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 // DigestErr is returned when content's digest conflicts with an expected value

--- a/digest/map.go
+++ b/digest/map.go
@@ -2,6 +2,7 @@ package digest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -240,7 +241,7 @@ func MapMakerFrom(m *Map) (*MapMaker, error) {
 	return mm, nil
 }
 
-// Add adds digest d and path p to the Map.  The digest d may be added using a
+// Add adds digest d and path p to the Map. The digest d may be added using a
 // modified form. For example, if the lowercase version of the digest exists and
 // the uppercase form is used in Add, the resulting digest map will associate
 // path p with the lowercase form. An error is returned if p is already present
@@ -251,6 +252,9 @@ func (mm *MapMaker) Add(d, p string) error {
 	mm.init()
 	if !validPath(p) {
 		return &MapPathInvalidErr{p}
+	}
+	if d == "" {
+		return errors.New("cannot add empty digest")
 	}
 	norm := normalizeDigest(d)
 	prevDigest, digestExists := mm.norms[norm]
@@ -273,6 +277,17 @@ func (mm *MapMaker) Add(d, p string) error {
 	}
 	return nil
 }
+
+// func (mm *MapMaker) GetDigest(p string) string {
+// 	if mm.tree == nil || mm.norms == nil {
+// 		return ""
+// 	}
+// 	n, err := mm.tree.Get(p)
+// 	if err != nil {
+// 		return ""
+// 	}
+// 	return mm.norms[n.Val]
+// }
 
 // Map returns a point to a new [Map] as constructed or modified by the MapMaker
 func (mm *MapMaker) Map() *Map {

--- a/digest/map.go
+++ b/digest/map.go
@@ -77,8 +77,9 @@ func (m Map) allPathDigests() (map[string]string, error) {
 	return files, nil
 }
 
-// Normalized returns a copy of the map with normalized (lowercase) digests. An
-// error is returned if the same digest appears more than once.
+// Normalized returns a copy of the map with normalized (lowercase) digests and
+// sorted slice of paths. An error is returned if the same digest appears more
+// than once.
 func (m Map) Normalized() (*Map, error) {
 	cp := &Map{
 		digests: make(map[string][]string, len(m.digests)),
@@ -88,8 +89,9 @@ func (m Map) Normalized() (*Map, error) {
 		if _, exists := cp.digests[norm]; exists {
 			return nil, &MapDigestConflictErr{Digest: norm}
 		}
-		cp.digests[norm] = make([]string, 0, len(paths))
-		cp.digests[norm] = append(cp.digests[digest], m.digests[digest]...)
+		normpaths := append(make([]string, 0, len(paths)), m.digests[digest]...)
+		sort.Strings(normpaths)
+		cp.digests[norm] = normpaths
 	}
 	return cp, nil
 }

--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -358,6 +358,9 @@ func NewInventory(stage *ocfl.Stage, id string, spec ocfl.Spec, contDir string, 
 		contDir = contentDir
 	}
 	head := ocfl.V(1, padding)
+	if err := head.Valid(); err != nil {
+		return nil, fmt.Errorf("invalid padding: %d", padding)
+	}
 	inv := &Inventory{
 		ID:               id,
 		Head:             head,
@@ -405,7 +408,7 @@ func NewInventory(stage *ocfl.Stage, id string, spec ocfl.Spec, contDir string, 
 		return nil
 	}
 	if err := stage.Walk(walkFn); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("in new inventory stage: %w", err)
 	}
 	maps := map[string]*digest.Map{}
 	for alg, maker := range makers {

--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -353,7 +353,7 @@ func mergeStageManifests(stage *ocfl.Stage, manifests map[string]*digest.Map, re
 // directory to the content path found in the stage. All staged files must have
 // content paths or else the stage is considered incomplete and an error is
 // returne.
-func NewInventory(stage *ocfl.Stage, id string, spec ocfl.Spec, contDir string, padding int, created time.Time, msg string, user *User) (*Inventory, error) {
+func NewInventory(stage *ocfl.Stage, id string, contDir string, padding int, created time.Time, msg string, user *User) (*Inventory, error) {
 	if contDir == "" {
 		contDir = contentDir
 	}
@@ -361,10 +361,13 @@ func NewInventory(stage *ocfl.Stage, id string, spec ocfl.Spec, contDir string, 
 	if err := head.Valid(); err != nil {
 		return nil, fmt.Errorf("invalid padding: %d", padding)
 	}
+	if alg := stage.DigestAlg().ID(); !algorithms[alg] {
+		return nil, fmt.Errorf("invalid digest algorithm %s", alg)
+	}
 	inv := &Inventory{
 		ID:               id,
 		Head:             head,
-		Type:             spec.AsInvType(),
+		Type:             defaultSpec.AsInvType(),
 		DigestAlgorithm:  stage.DigestAlg().ID(),
 		ContentDirectory: contDir,
 		Versions: map[ocfl.VNum]*Version{

--- a/ocflv1/inventory.go
+++ b/ocflv1/inventory.go
@@ -216,7 +216,7 @@ func (inv *Inventory) Index(ver ocfl.VNum) (*ocfl.Index, error) {
 func (inv Inventory) NextVersionInventory(stage *ocfl.Stage, created time.Time, msg string, user *User) (*Inventory, error) {
 	next, err := inv.Head.Next()
 	if err != nil {
-		return nil, fmt.Errorf("the inventory's version numbering scheme does support versions beyond %s: %w", inv.Head, err)
+		return nil, fmt.Errorf("the inventory's version numbering scheme does not support versions beyond %s: %w", inv.Head, err)
 	}
 	algid := stage.DigestAlg().ID()
 	if inv.DigestAlgorithm != algid {

--- a/ocflv1/inventory_test.go
+++ b/ocflv1/inventory_test.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/srerickson/ocfl"
-	"github.com/srerickson/ocfl/internal/testfs"
+	"github.com/srerickson/ocfl/digest"
 	"github.com/srerickson/ocfl/ocflv1"
 )
 
@@ -62,52 +63,125 @@ func TestInventoryIndex(t *testing.T) {
 }
 
 func TestInventorNextVersionInventory(t *testing.T) {
-	fsys := ocfl.DirFS(goodObjPath)
 	ctx := context.Background()
+	fsys := ocfl.DirFS(goodObjPath)
 	goodObjects, err := fsys.ReadDir(ctx, ".")
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, dir := range goodObjects {
 		t.Run(dir.Name(), func(t *testing.T) {
-			ctx := context.Background()
 			name := path.Join(dir.Name(), "inventory.json")
 			inv, result := ocflv1.ValidateInventory(ctx, fsys, name, nil)
 			if err := result.Err(); err != nil {
 				t.Fatal(err)
 			}
-			// build a new inventory from modified stage
-			stagefs := testfs.NewMemFS()
-			idx, _ := inv.Index(ocfl.VNum{})
-			stage := ocfl.NewStage(inv.Alg(), ocfl.StageIndex(idx), ocfl.StageRoot(stagefs, "."))
-			if _, err := stage.WriteFile(ctx, "newfile.txt", strings.NewReader("new file content")); err != nil {
-				t.Fatal(err)
-			}
-			created := time.Now()
-			msg := "new version"
-			user := &ocflv1.User{Name: "Me", Address: "email:me@me.com"}
-			newInv, err := inv.NextVersionInventory(stage, created, msg, user)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// new inventory is valid
-			if err := newInv.Validate().Err(); err != nil {
-				t.Fatal("new inventory is not valid", err)
-			}
-			// new inventory has one more version than previous
-			if len(newInv.Versions) != len(inv.Versions)+1 {
-				t.Fatal("new inventory doesn't have additional version")
-			}
-			ver := newInv.Versions[newInv.Head]
-			if ver.Created.Unix() != created.Unix() {
-				t.Fatal("new version doesn't have right created timestamp")
-			}
-			if ver.Message != msg {
-				t.Fatal("new version doesn't have right message")
-			}
-			if ver.User != user {
-				t.Fatal("new version doesn't have right user")
-			}
+			t.Run("empty stage", func(t *testing.T) {
+				stage := ocfl.NewStage(inv.Alg())
+				nextVersionInventoryTest(t, inv, stage, "new version", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+			})
+			t.Run("newfile", func(t *testing.T) {
+				stage := ocfl.NewStage(inv.Alg())
+				stage.UnsafeAdd("newfile.txt", "content.txt", digest.Set{inv.DigestAlgorithm: "abcd"})
+				nextVersionInventoryTest(t, inv, stage, "new version", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+			})
+			t.Run("re-add-digest", func(t *testing.T) {
+				// add file with lowercase digest, then remove it, then add it back as uppercase.
+				// this is meant to test merging a stage with a source path and a digest that already exists in the inventory.
+				// stage 1 -- new file, whacky digest format
+				stage1 := ocfl.NewStage(inv.Alg())
+				stage1.UnsafeAdd("newfile.txt", "content.txt", digest.Set{inv.DigestAlgorithm: "aBcD"})
+				newInv, err := inv.NextVersionInventory(stage1, time.Now(), "add a new file", &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				// stage 2 -- remove everything
+				stage2 := ocfl.NewStage(inv.Alg())
+				newInv, err = newInv.NextVersionInventory(stage2, time.Now(), "remove the file", &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				// stage 3 -- readd the file, with uppercase
+				stage3 := ocfl.NewStage(inv.Alg())
+				stage3.UnsafeAdd("newfile.txt", "content.txt", digest.Set{inv.DigestAlgorithm: "ABCD"})
+				nextVersionInventoryTest(t, newInv, stage2, "update again", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+			})
+
 		})
+
+	}
+}
+
+// complete test for NextVersionInventory
+func nextVersionInventoryTest(t *testing.T, inv *ocflv1.Inventory, stage *ocfl.Stage, msg string, created time.Time, user *ocflv1.User) *ocflv1.Inventory {
+	newInv, err := inv.NextVersionInventory(stage, created, msg, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	isNil(t, newInv.Validate().Err(), "new inventory is invalid")
+	isEq(t, newInv.ContentDirectory, inv.ContentDirectory, "new inventory content directory")
+	isEq(t, newInv.ID, inv.ID, "new inventory object id")
+	isEq(t, newInv.Head.Num(), inv.Head.Num()+1, "new inventory head")
+	isEq(t, newInv.Type, inv.Type, "new inventory type field")
+	isEq(t, len(newInv.Versions), len(inv.Versions)+1, "number of versions in new inventory")
+	// check all manifest entries in old inv are also in new inv
+	inv.Manifest.EachPath(func(name string, digest string) error {
+		// digests in new inventory are always lowercase
+		isEq(t, newInv.Manifest.GetDigest(name), strings.ToLower(digest), "manifest entry for", name)
+		return nil
+	})
+	// check all versions in old inv are in new
+	for num, expVer := range inv.Versions {
+		t.Run("version-"+num.String(), func(t *testing.T) {
+			gotVer := newInv.Versions[num]
+			isEq(t, gotVer.Created, expVer.Created, "created field")
+			isEq(t, gotVer.Message, expVer.Message, "message field")
+			isEq(t, gotVer.User, expVer.User, "user")
+			isEq(t, len(gotVer.State.AllPaths()), len(expVer.State.AllPaths()), "state's number of paths")
+			expVer.State.EachPath(func(name string, digest string) error {
+				isEq(t, gotVer.State.GetDigest(name), strings.ToLower(digest), "state for path", name)
+				return nil
+			})
+		})
+	}
+	// check the new version
+	headVer := newInv.Versions[newInv.Head]
+	isEq(t, headVer.Created.Unix(), created.Unix(), "new version timestamp (unix)")
+	isEq(t, headVer.Message, msg, "new version message")
+	isEq(t, headVer.User, user, "new version user")
+	stage.Walk(func(name string, node *ocfl.Index) error {
+		if node.IsDir() {
+			return nil
+		}
+		gotdigest := headVer.State.GetDigest(name)
+		expDigest := strings.ToLower(node.Val().Digests[inv.DigestAlgorithm])
+		isNot(t, gotdigest, "", fmt.Sprintf("new version state is missing '%s'", name))
+		isEq(t, gotdigest, expDigest, fmt.Sprintf("new version state is missing '%s'", name))
+		// every source path in the stage should be added to the manifest
+		// with the version content directory as a prefix
+		for _, src := range node.Val().SrcPaths {
+			expPath := path.Join(newInv.Head.String(), newInv.ContentDirectory, src)
+			isNot(t, newInv.Manifest.GetDigest(expPath), "missing manifest entry for", src)
+		}
+		return nil
+	})
+	return newInv
+}
+
+func isEq(t *testing.T, got any, exp any, desc ...string) {
+	if !reflect.DeepEqual(got, exp) {
+		t.Fatalf("%s: got='%v', expect='%v'", fmt.Sprint(desc), got, exp)
+	}
+}
+
+func isNot(t *testing.T, got any, exp any, desc ...string) {
+	if reflect.DeepEqual(got, exp) {
+		t.Fatalf("%s: val='%v'", fmt.Sprint(desc), got)
+	}
+}
+
+func isNil(t *testing.T, v any, desc ...string) {
+	if v != nil {
+		t.Fatalf("%s: '%v'", fmt.Sprint(desc), v)
 	}
 }

--- a/ocflv1/inventory_test.go
+++ b/ocflv1/inventory_test.go
@@ -1,9 +1,7 @@
 package ocflv1_test
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -58,38 +56,6 @@ func TestInventoryIndex(t *testing.T) {
 			})
 			if err != nil {
 				t.Fatal(err)
-			}
-		})
-	}
-}
-
-func TestInventoryCopy(t *testing.T) {
-	fsys := ocfl.DirFS(goodObjPath)
-	ctx := context.Background()
-	goodObjects, err := fsys.ReadDir(ctx, ".")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, dir := range goodObjects {
-		t.Run(dir.Name(), func(t *testing.T) {
-			name := path.Join(dir.Name(), "inventory.json")
-			inv, result := ocflv1.ValidateInventory(ctx, fsys, name, nil)
-			if err := result.Err(); err != nil {
-				t.Fatal(err)
-			}
-			cp := inv.Copy()
-			expBytes, err := json.Marshal(inv)
-			if err != nil {
-				t.Fatal(err)
-			}
-			gotBytes, err := json.Marshal(cp)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(expBytes, gotBytes) {
-				t.Log("expect", string(expBytes))
-				t.Log("got", string(gotBytes))
-				t.Fatal("copied inventory isn't a match")
 			}
 		})
 	}

--- a/ocflv1/inventory_test.go
+++ b/ocflv1/inventory_test.go
@@ -99,7 +99,7 @@ func TestInventorNextVersionInventory(t *testing.T) {
 				t.Fatal("new inventory doesn't have additional version")
 			}
 			ver := newInv.Versions[newInv.Head]
-			if ver.Created.UTC().Truncate(time.Second) != created.UTC().Truncate(time.Second) {
+			if ver.Created.Unix() != created.Unix() {
 				t.Fatal("new version doesn't have right created timestamp")
 			}
 			if ver.Message != msg {

--- a/ocflv1/inventory_test.go
+++ b/ocflv1/inventory_test.go
@@ -62,6 +62,68 @@ func TestInventoryIndex(t *testing.T) {
 	}
 }
 
+func TestNewInventory(t *testing.T) {
+	// The strategy of this test is essentially rebuild the inventories for each
+	// of the good fixture objects step by step.
+	ctx := context.Background()
+	fsys := ocfl.DirFS(goodObjPath)
+	goodObjects, err := fsys.ReadDir(ctx, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range goodObjects {
+		t.Run(dir.Name(), func(t *testing.T) {
+			name := path.Join(dir.Name(), "inventory.json")
+			inv, _ := ocflv1.ValidateInventory(ctx, fsys, name, nil)
+			// FIXME: this api is awkward. Index should just take an int
+			v1 := ocfl.V(1, inv.Head.Padding())
+			ver := inv.Versions[v1]
+			idx, err := inv.Index(v1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// set up a stage that reads from object root -- generally a bad idea
+			stage1 := ocfl.NewStage(inv.Alg(), ocfl.StageRoot(fsys, dir.Name()))
+			// FIXME: this is so ugly. Granted, it's a strange use case but there
+			// should be an easier way to iterate over logical paths and their
+			// contents. Doing this through an index is overkill.
+			idx.Walk(func(name string, tree *ocfl.Index) error {
+				if tree.IsDir() {
+					return nil
+				}
+				src := tree.Val().SrcPaths[0]
+				digest := tree.Val().Digests
+				return stage1.UnsafeAdd(name, src, digest)
+			})
+			newInv := newInventoryTest(t, stage1,
+				inv.ID,
+				inv.ContentDirectory,
+				inv.Head.Padding(),
+				ver.Created, ver.Message, ver.User)
+
+			for i := 2; i <= inv.Head.Num(); i++ {
+				vnum := ocfl.V(i, inv.Head.Padding())
+				idx, err := inv.Index(vnum)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ver := inv.Versions[vnum]
+				stage := ocfl.NewStage(inv.Alg(), ocfl.StageIndex(idx), ocfl.StageRoot(fsys, dir.Name()))
+				idx.Walk(func(name string, tree *ocfl.Index) error {
+					if tree.IsDir() {
+						return nil
+					}
+					src := tree.Val().SrcPaths[0]
+					digest := tree.Val().Digests
+					return stage.UnsafeAdd(name, src, digest)
+				})
+				newInv = nextVersionInventoryTest(t, newInv, stage, ver.Created, ver.Message, ver.User)
+			}
+		})
+
+	}
+}
+
 func TestInventorNextVersionInventory(t *testing.T) {
 	ctx := context.Background()
 	fsys := ocfl.DirFS(goodObjPath)
@@ -78,17 +140,17 @@ func TestInventorNextVersionInventory(t *testing.T) {
 			}
 			t.Run("empty stage", func(t *testing.T) {
 				stage := ocfl.NewStage(inv.Alg())
-				nextVersionInventoryTest(t, inv, stage, "new version", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+				nextVersionInventoryTest(t, inv, stage, time.Now(), "new version", &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
 			})
 			t.Run("stage newfile", func(t *testing.T) {
 				stage := ocfl.NewStage(inv.Alg())
 				stage.UnsafeAdd("newfile.txt", "content.txt", digest.Set{inv.DigestAlgorithm: "abcd"})
-				nextVersionInventoryTest(t, inv, stage, "new version", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+				nextVersionInventoryTest(t, inv, stage, time.Now(), "new version", &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
 			})
 			t.Run("stage newfile, fixity", func(t *testing.T) {
 				stage := ocfl.NewStage(inv.Alg())
 				stage.UnsafeAdd("newfile.txt", "content.txt", digest.Set{inv.DigestAlgorithm: "abcd", digest.MD5().ID(): "1234"})
-				nextVersionInventoryTest(t, inv, stage, "new version", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+				nextVersionInventoryTest(t, inv, stage, time.Now(), "new version", &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
 			})
 			t.Run("stage re-add-digest", func(t *testing.T) {
 				// add file with lowercase digest, then remove it, then add it back as uppercase.
@@ -109,7 +171,7 @@ func TestInventorNextVersionInventory(t *testing.T) {
 				// stage 3 -- readd the file, with uppercase
 				stage3 := ocfl.NewStage(inv.Alg())
 				stage3.UnsafeAdd("newfile.txt", "content.txt", digest.Set{inv.DigestAlgorithm: "ABCD"})
-				nextVersionInventoryTest(t, newInv, stage2, "update again", time.Now(), &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
+				nextVersionInventoryTest(t, newInv, stage2, time.Now(), "update again", &ocflv1.User{Name: "Me", Address: "email:me@me.com"})
 			})
 
 		})
@@ -117,8 +179,63 @@ func TestInventorNextVersionInventory(t *testing.T) {
 	}
 }
 
+func newInventoryTest(t *testing.T, stage *ocfl.Stage, id string, contDir string, padding int, created time.Time, msg string, user *ocflv1.User) *ocflv1.Inventory {
+	newInv, err := ocflv1.NewInventory(stage, id, contDir, padding, created, msg, user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	isNil(t, newInv.Validate().Err(), "new inventory is invalid")
+	if contDir == "" {
+		contDir = "content"
+	}
+	isEq(t, newInv.ContentDirectory, contDir, "new inventory content directory")
+	isEq(t, newInv.ID, id, "new inventory object id")
+	isEq(t, newInv.Head, ocfl.V(1, padding), "new inventory head")
+	// check version
+	headVer := newInv.Versions[newInv.Head]
+	isEq(t, headVer.Created.Unix(), created.Unix(), "new version timestamp (unix)")
+	isEq(t, headVer.Message, msg, "new version message")
+	isEq(t, headVer.User, user, "new version user")
+	stage.Walk(func(lgcPath string, node *ocfl.Index) error {
+		if node.IsDir() {
+			return nil
+		}
+		stageDigests := node.Val().Digests
+		stageDigest := stageDigests[newInv.DigestAlgorithm]
+		stateDigest := headVer.State.GetDigest(lgcPath)
+		isNot(t, stateDigest, "", fmt.Sprintf("new version state is missing '%s'", lgcPath))
+		isEq(t, stateDigest, strings.ToLower(stageDigest), fmt.Sprintf("wrong digest in version state for '%s'", lgcPath))
+		// the stage digest should be associacate with all source paths in the
+		// manifest. Every source path in the stage should be added to the
+		// manifest with the version content directory as a prefix
+		for _, src := range node.Val().SrcPaths {
+			expPath := path.Join(newInv.Head.String(), newInv.ContentDirectory, src)
+			manifestDigest := newInv.Manifest.GetDigest(expPath)
+			isEq(t, manifestDigest, strings.ToLower(stageDigest), "manifest digest for", expPath)
+		}
+		// additional digests in the stage should be present in the
+		// appropriate fixity block for the new inventory.
+		for alg, stageDigest := range node.Val().Digests {
+			if alg == newInv.DigestAlgorithm {
+				continue
+			}
+			fixity := newInv.Fixity[alg]
+			if fixity == nil {
+				t.Fatal("missing fixity for ", alg)
+			}
+			for _, src := range node.Val().SrcPaths {
+				expPath := path.Join(newInv.Head.String(), newInv.ContentDirectory, src)
+				fixityDigest := fixity.GetDigest(expPath)
+				isEq(t, fixityDigest, strings.ToLower(stageDigest), "fixity digest for", expPath)
+			}
+		}
+		return nil
+	})
+	return newInv
+}
+
 // complete test for NextVersionInventory
-func nextVersionInventoryTest(t *testing.T, inv *ocflv1.Inventory, stage *ocfl.Stage, msg string, created time.Time, user *ocflv1.User) *ocflv1.Inventory {
+func nextVersionInventoryTest(t *testing.T, inv *ocflv1.Inventory, stage *ocfl.Stage, created time.Time, msg string, user *ocflv1.User) *ocflv1.Inventory {
 	newInv, err := inv.NextVersionInventory(stage, created, msg, user)
 	if err != nil {
 		t.Fatal(err)
@@ -129,9 +246,8 @@ func nextVersionInventoryTest(t *testing.T, inv *ocflv1.Inventory, stage *ocfl.S
 	isEq(t, newInv.Head.Num(), inv.Head.Num()+1, "new inventory head")
 	isEq(t, newInv.Type, inv.Type, "new inventory type field")
 	isEq(t, len(newInv.Versions), len(inv.Versions)+1, "number of versions in new inventory")
-	// check all manifest entries in old inv are also in new inv
+	// check all manifest entries in old inv are also in new inv (lowercase)
 	inv.Manifest.EachPath(func(name string, digest string) error {
-		// digests in new inventory are always lowercase
 		isEq(t, newInv.Manifest.GetDigest(name), strings.ToLower(digest), "manifest entry for", name)
 		return nil
 	})
@@ -187,7 +303,7 @@ func nextVersionInventoryTest(t *testing.T, inv *ocflv1.Inventory, stage *ocfl.S
 		for _, src := range node.Val().SrcPaths {
 			expPath := path.Join(newInv.Head.String(), newInv.ContentDirectory, src)
 			manifestDigest := newInv.Manifest.GetDigest(expPath)
-			isEq(t, manifestDigest, stageDigest, "manifest digest for", expPath)
+			isEq(t, manifestDigest, strings.ToLower(stageDigest), "manifest digest for", expPath)
 		}
 		// additional digests in the stage should be present in the
 		// appropriate fixity block for the new inventory.
@@ -211,18 +327,21 @@ func nextVersionInventoryTest(t *testing.T, inv *ocflv1.Inventory, stage *ocfl.S
 }
 
 func isEq(t *testing.T, got any, exp any, desc ...string) {
+	t.Helper()
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("%s: got='%v', expect='%v'", fmt.Sprint(desc), got, exp)
 	}
 }
 
 func isNot(t *testing.T, got any, not any, desc ...string) {
+	t.Helper()
 	if reflect.DeepEqual(got, not) {
 		t.Fatalf("%s: val='%v'", fmt.Sprint(desc), not)
 	}
 }
 
 func isNil(t *testing.T, v any, desc ...string) {
+	t.Helper()
 	if v != nil {
 		t.Fatalf("%s: '%v'", fmt.Sprint(desc), v)
 	}

--- a/ocflv1/inventory_test.go
+++ b/ocflv1/inventory_test.go
@@ -1,13 +1,18 @@
 package ocflv1_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/srerickson/ocfl"
+	"github.com/srerickson/ocfl/internal/testfs"
 	"github.com/srerickson/ocfl/ocflv1"
 )
 
@@ -53,6 +58,89 @@ func TestInventoryIndex(t *testing.T) {
 			})
 			if err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestInventoryCopy(t *testing.T) {
+	fsys := ocfl.DirFS(goodObjPath)
+	ctx := context.Background()
+	goodObjects, err := fsys.ReadDir(ctx, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range goodObjects {
+		t.Run(dir.Name(), func(t *testing.T) {
+			name := path.Join(dir.Name(), "inventory.json")
+			inv, result := ocflv1.ValidateInventory(ctx, fsys, name, nil)
+			if err := result.Err(); err != nil {
+				t.Fatal(err)
+			}
+			cp := inv.Copy()
+			expBytes, err := json.Marshal(inv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotBytes, err := json.Marshal(cp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(expBytes, gotBytes) {
+				t.Log("expect", string(expBytes))
+				t.Log("got", string(gotBytes))
+				t.Fatal("copied inventory isn't a match")
+			}
+		})
+	}
+}
+
+func TestInventorNextVersionInventory(t *testing.T) {
+	fsys := ocfl.DirFS(goodObjPath)
+	ctx := context.Background()
+	goodObjects, err := fsys.ReadDir(ctx, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range goodObjects {
+		t.Run(dir.Name(), func(t *testing.T) {
+			ctx := context.Background()
+			name := path.Join(dir.Name(), "inventory.json")
+			inv, result := ocflv1.ValidateInventory(ctx, fsys, name, nil)
+			if err := result.Err(); err != nil {
+				t.Fatal(err)
+			}
+			// build a new inventory from modified stage
+			stagefs := testfs.NewMemFS()
+			idx, _ := inv.Index(ocfl.VNum{})
+			stage := ocfl.NewStage(inv.Alg(), ocfl.StageIndex(idx), ocfl.StageRoot(stagefs, "."))
+			if _, err := stage.WriteFile(ctx, "newfile.txt", strings.NewReader("new file content")); err != nil {
+				t.Fatal(err)
+			}
+			created := time.Now()
+			msg := "new version"
+			user := &ocflv1.User{Name: "Me", Address: "email:me@me.com"}
+			newInv, err := inv.NextVersionInventory(stage, created, msg, user)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// new inventory is valid
+			if err := newInv.Validate().Err(); err != nil {
+				t.Fatal("new inventory is not valid", err)
+			}
+			// new inventory has one more version than previous
+			if len(newInv.Versions) != len(inv.Versions)+1 {
+				t.Fatal("new inventory doesn't have additional version")
+			}
+			ver := newInv.Versions[newInv.Head]
+			if ver.Created.UTC().Truncate(time.Second) != created.UTC().Truncate(time.Second) {
+				t.Fatal("new version doesn't have right created timestamp")
+			}
+			if ver.Message != msg {
+				t.Fatal("new version doesn't have right message")
+			}
+			if ver.User != user {
+				t.Fatal("new version doesn't have right user")
 			}
 		})
 	}

--- a/ocflv1/inventory_validation.go
+++ b/ocflv1/inventory_validation.go
@@ -245,6 +245,7 @@ func ValidateInventoryReader(ctx context.Context, reader io.Reader, alg digest.A
 	if err := result.Err(); err != nil {
 		return nil, result
 	}
+	inv.alg = alg
 	inv.digest = sum
 	return inv, result
 }

--- a/ocflv1/object.go
+++ b/ocflv1/object.go
@@ -138,7 +138,7 @@ func (obj *Object) NewStage(ctx context.Context, ver ocfl.VNum, opts ...ocfl.Sta
 	if err != nil {
 		return nil, err
 	}
-	idx, err := inv.Index(ver)
+	idx, err := inv.Index(ver.Num())
 	if err != nil {
 		return nil, err
 	}

--- a/ocflv1/object_test.go
+++ b/ocflv1/object_test.go
@@ -34,7 +34,7 @@ func TestReadObject(t *testing.T) {
 	if inv.Head.Num() != 3 {
 		t.Error("expected head to be version 3")
 	}
-	cont, err := inv.ContentPath(ocfl.VNum{}, "foo/bar.xml")
+	cont, err := inv.ContentPath(0, "foo/bar.xml")
 	if err != nil {
 		t.Error(err)
 	}

--- a/ocflv1/object_test.go
+++ b/ocflv1/object_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/srerickson/ocfl/ocflv1"
 )
 
-var fixturePath = filepath.Join(`..`, `testdata`, `object-fixtures`, `1.0`)
+var fixturePath = filepath.Join(`..`, `testdata`, `object-fixtures`, `1.1`)
 var goodObjPath = filepath.Join(fixturePath, `good-objects`)
 
+//var warnObjPath = filepath.Join(fixturePath, `warn-objects`)
 //var badObjPath = filepath.Join(fixturePath, `bad-objects`)
 
 func TestReadObject(t *testing.T) {

--- a/ocflv1/object_validation.go
+++ b/ocflv1/object_validation.go
@@ -310,8 +310,8 @@ func (vldr *objectValidator) validateVersionInventory(ctx context.Context, vn oc
 	// confirm version states in the version inventory match root inventory
 	for v, ver := range inv.Versions {
 		rootVer := vldr.rootInv.Versions[v]
-		rootState, _ := vldr.rootInv.Index(v)
-		verState, _ := inv.Index(v)
+		rootState, _ := vldr.rootInv.Index(v.Num())
+		verState, _ := inv.Index(v.Num())
 		changes, err := rootState.Diff(*verState)
 		if err != nil {
 			err := fmt.Errorf("unexpected err durring inventory diff: %w", err)

--- a/ocflv1/store_commit.go
+++ b/ocflv1/store_commit.go
@@ -59,13 +59,9 @@ func (s *Store) Commit(ctx context.Context, id string, stage *ocfl.Stage, opts .
 		if err != nil {
 			return fmt.Errorf("while building next inventory: %w", err)
 		}
-		// TODO: handle bumping OCFL spec. Also need to replace NAMASTE!
-		// if comm.spec.Cmp(newInv.Type.Spec) > 0 {
-		// 	newInv.Type = comm.spec.AsInvType()
-		// }
 	} else {
 		// new object
-		newInv, err = NewInventory(stage, id, comm.spec, comm.contentDir, comm.padding, comm.created, comm.message, &comm.user)
+		newInv, err = NewInventory(stage, id, comm.contentDir, comm.padding, comm.created, comm.message, &comm.user)
 		if err != nil {
 			return fmt.Errorf("while building new inventory: %w", err)
 		}

--- a/ocflv1/store_commit_test.go
+++ b/ocflv1/store_commit_test.go
@@ -140,7 +140,7 @@ func TestStoreCommit(t *testing.T) {
 			t.Fatal("expected a message for version", num)
 		}
 	}
-	idx, err := inv.Index(ocfl.Head)
+	idx, err := inv.Index(ocfl.Head.Num())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ocflv1/store_commit_test.go
+++ b/ocflv1/store_commit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing/fstest"
 
 	"github.com/srerickson/ocfl"
+	"github.com/srerickson/ocfl/backend/local"
 	"github.com/srerickson/ocfl/digest"
 	"github.com/srerickson/ocfl/internal/testfs"
 	"github.com/srerickson/ocfl/ocflv1"
@@ -15,7 +16,8 @@ import (
 func TestStoreCommit(t *testing.T) {
 	storePath := "test-stage"
 	ctx := context.Background()
-	storeFS := testfs.NewMemFS() // store
+	//storeFS := testfs.NewMemFS() // store
+	storeFS, _ := local.NewFS("tmp")
 	stgFS := ocfl.NewFS(fstest.MapFS{
 		`stage1/tmp.txt`:       &fstest.MapFile{Data: []byte(`content1`)},
 		`stage3/a/tmp.txt`:     &fstest.MapFile{Data: []byte(`content2`)},

--- a/ocflv1/store_commit_test.go
+++ b/ocflv1/store_commit_test.go
@@ -7,7 +7,6 @@ import (
 	"testing/fstest"
 
 	"github.com/srerickson/ocfl"
-	"github.com/srerickson/ocfl/backend/local"
 	"github.com/srerickson/ocfl/digest"
 	"github.com/srerickson/ocfl/internal/testfs"
 	"github.com/srerickson/ocfl/ocflv1"
@@ -16,8 +15,7 @@ import (
 func TestStoreCommit(t *testing.T) {
 	storePath := "test-stage"
 	ctx := context.Background()
-	//storeFS := testfs.NewMemFS() // store
-	storeFS, _ := local.NewFS("tmp")
+	storeFS := testfs.NewMemFS() // store
 	stgFS := ocfl.NewFS(fstest.MapFS{
 		`stage1/tmp.txt`:       &fstest.MapFile{Data: []byte(`content1`)},
 		`stage3/a/tmp.txt`:     &fstest.MapFile{Data: []byte(`content2`)},

--- a/stage.go
+++ b/stage.go
@@ -268,10 +268,16 @@ func (stage *Stage) UnsafeAdd(lgcPath string, srcPath string, digests digest.Set
 	if stage.srcFiles == nil {
 		stage.srcFiles = make(map[string]struct{})
 	}
-	info := IndexItem{Digests: digests, SrcPaths: []string{srcPath}}
+	var srcs []string
+	if srcPath != "" {
+		srcs = []string{srcPath}
+	}
+	info := IndexItem{Digests: digests, SrcPaths: srcs}
 	stage.srcFiles[srcPath] = struct{}{}
 	if err := stage.idx.node.SetFile(lgcPath, info); err != nil {
-		delete(stage.srcFiles, srcPath)
+		if srcPath != "" {
+			delete(stage.srcFiles, srcPath)
+		}
 		return err
 	}
 	return nil

--- a/stage_test.go
+++ b/stage_test.go
@@ -99,11 +99,10 @@ func TestNewStage(t *testing.T) {
 		t.Fatalf("expected a %s value", algID)
 	}
 	// manifest should include two entries
-	mans, err := stg.AllManifests(nil)
+	man, err := stg.Manifest()
 	if err != nil {
 		t.Fatal(err)
 	}
-	man := mans[stg.DigestAlg().ID()]
 	if l := len(man.AllPaths()); l != 2 {
 		t.Fatalf("expected 2 entries in the manifest, got %d: %v", l, man.AllPaths())
 	}
@@ -111,14 +110,6 @@ func TestNewStage(t *testing.T) {
 	st := stg.VersionState()
 	if l := len(st.AllPaths()); l != 2 {
 		t.Fatalf("expected 2 entries in the state, got %v", st.AllPaths())
-	}
-	// manifests for md5 and stage algo
-	mans, err = stg.AllManifests(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if l := len(mans); l != 2 {
-		t.Fatalf("expected 1 entries in fixity, got %d", l)
 	}
 	// validate stage digests
 	if err := validateStageDigests(context.Background(), stg); err != nil {
@@ -318,11 +309,7 @@ func TestStageWrite(t *testing.T) {
 			t.Fatal(err)
 		}
 		// check that added files are in manifest
-		mans, err := stg.AllManifests(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		man := mans[stg.DigestAlg().ID()]
+		man, err := stg.Manifest()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/stage_test.go
+++ b/stage_test.go
@@ -99,10 +99,11 @@ func TestNewStage(t *testing.T) {
 		t.Fatalf("expected a %s value", algID)
 	}
 	// manifest should include two entries
-	man, err := stg.Manifest()
+	mans, err := stg.AllManifests(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	man := mans[stg.DigestAlg().ID()]
 	if l := len(man.AllPaths()); l != 2 {
 		t.Fatalf("expected 2 entries in the manifest, got %d: %v", l, man.AllPaths())
 	}
@@ -111,12 +112,12 @@ func TestNewStage(t *testing.T) {
 	if l := len(st.AllPaths()); l != 2 {
 		t.Fatalf("expected 2 entries in the state, got %v", st.AllPaths())
 	}
-	// fixity should have md5
-	fix, err := stg.Fixity()
+	// manifests for md5 and stage algo
+	mans, err = stg.AllManifests(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if l := len(fix); l != 1 {
+	if l := len(mans); l != 2 {
 		t.Fatalf("expected 1 entries in fixity, got %d", l)
 	}
 	// validate stage digests
@@ -317,7 +318,11 @@ func TestStageWrite(t *testing.T) {
 			t.Fatal(err)
 		}
 		// check that added files are in manifest
-		man, err := stg.Manifest()
+		mans, err := stg.AllManifests(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		man := mans[stg.DigestAlg().ID()]
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
- Adds `ocflv1.NewInventory` for creating a new Inventory from a stage
- Adds  `NextVersionInventory()` method to `ocflv1.Inventory` for creating successor inventories based on contents of a stage.
- Tests for both
- Additional convenience methods for `ocflv1.Inventory` that ease accessing versions and logical state
- Some necessary changes to `digest.Map` and `digest.MapMaker` for dealing with mixed case digest strings and normalization.
- For ease of use, `ocflv1.Inventory`'s `Index()` and `ContentPath()` methods use an int to refer to the version.
- Additional small stuff