### PR TITLE
Fix commit

### DIFF
--- a/cmd/gocfl/cmd/commit.go
+++ b/cmd/gocfl/cmd/commit.go
@@ -124,7 +124,7 @@ func runCommit(ctx context.Context, conf *Config) {
 	commitUI := &ProgressWriter{preamble: "committing " + commitFlags.objectID + " "}
 	commitOpts := []ocflv1.CommitOption{
 		ocflv1.WithMessage(commitFlags.commitMsg),
-		ocflv1.WithUser(commitFlags.userName, commitFlags.userAddr),
+		ocflv1.WithUser(ocflv1.User{Name: commitFlags.userName, Address: commitFlags.userAddr}),
 		ocflv1.WithLogger(log),
 	}
 	commitFn := func(w io.Writer) error {

--- a/ocflv1/store_commit.go
+++ b/ocflv1/store_commit.go
@@ -55,13 +55,13 @@ func (s *Store) Commit(ctx context.Context, id string, stage *ocfl.Stage, opts .
 		if err != nil {
 			return err
 		}
-		newInv, err = prevInv.NextVersionInventory(stage, comm.created, comm.message, &comm.user)
+		newInv, err = prevInv.NextVersionInventory(stage, comm.created, comm.message, comm.user)
 		if err != nil {
 			return fmt.Errorf("while building next inventory: %w", err)
 		}
 	} else {
 		// new object
-		newInv, err = NewInventory(stage, id, comm.contentDir, comm.padding, comm.created, comm.message, &comm.user)
+		newInv, err = NewInventory(stage, id, comm.contentDir, comm.padding, comm.created, comm.message, comm.user)
 		if err != nil {
 			return fmt.Errorf("while building new inventory: %w", err)
 		}
@@ -121,10 +121,9 @@ func WithMessage(msg string) CommitOption {
 }
 
 // WithUser sets the user for the new object version
-func WithUser(name, addr string) CommitOption {
+func WithUser(user User) CommitOption {
 	return func(comm *commit) {
-		comm.user.Name = name
-		comm.user.Address = addr
+		comm.user = &user
 	}
 }
 
@@ -165,7 +164,7 @@ type commit struct {
 	padding         int             // padding (new objects only)
 	contentDir      string          // content directory setting (new objects only)
 	contentPathFunc ContentPathFunc // function used to configure content paths
-	user            User
+	user            *User
 	message         string
 	created         time.Time
 

--- a/ocflv1/store_commit_test.go
+++ b/ocflv1/store_commit_test.go
@@ -31,6 +31,20 @@ func TestStoreCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	t.Run("without options", func(t *testing.T) {
+		stage := ocfl.NewStage(digest.SHA256()) // empty stage
+		if err = store.Commit(ctx, "object-0", stage); err != nil {
+			t.Fatal(err)
+		}
+		obj, err := store.GetObject(ctx, "object-0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := obj.Validate(ctx).Err(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	// v1 - add one file "tmp.txt"
 	stage1 := ocfl.NewStage(digest.SHA256(), ocfl.StageRoot(stgFS, `stage1`))
 	if err := stage1.AddAllFromRoot(ctx); err != nil {

--- a/ocflv1/store_commit_test.go
+++ b/ocflv1/store_commit_test.go
@@ -56,7 +56,7 @@ func TestStoreCommit(t *testing.T) {
 	if err = store.Commit(ctx, "object-1", stage1,
 		ocflv1.WithContentDir("foo"),
 		ocflv1.WithVersionPadding(2),
-		ocflv1.WithUser("Will", "mailto:Will@email.com"),
+		ocflv1.WithUser(ocflv1.User{Name: "Will", Address: "mailto:Will@email.com"}),
 		ocflv1.WithMessage("first commit"),
 	); err != nil {
 		t.Fatal(err)
@@ -75,7 +75,7 @@ func TestStoreCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := store.Commit(ctx, "object-1", stage2,
-		ocflv1.WithUser("Wanda", "mailto:wanda@email.com"),
+		ocflv1.WithUser(ocflv1.User{Name: "Wanda", Address: "mailto:wanda@email.com"}),
 		ocflv1.WithMessage("second commit")); err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestStoreCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := store.Commit(ctx, "object-1", stage3,
-		ocflv1.WithUser("Woody", "mailto:Woody@email.com"),
+		ocflv1.WithUser(ocflv1.User{Name: "Woody", Address: "mailto:Woody@email.com"}),
 		ocflv1.WithMessage("third commit"),
 	); err != nil {
 		t.Fatal(err)
@@ -116,7 +116,7 @@ func TestStoreCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := store.Commit(ctx, "object-1", stage4,
-		ocflv1.WithUser("Winnie", "mailto:Winnie@no.com"),
+		ocflv1.WithUser(ocflv1.User{Name: "Winnie", Address: "mailto:Winnie@no.com"}),
 		ocflv1.WithMessage("last commit"),
 	); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
fix Commit(): doesn't require additional options to produce a valid object
closes #31